### PR TITLE
Mention factory_factory_girl to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 factory_girl is a fixtures replacement with a straightforward definition syntax, support for multiple build strategies (saved instances, unsaved instances, attribute hashes, and stubbed objects), and support for multiple factories for the same class (user, admin_user, and so on), including factory inheritance.
 
 If you want to use factory_girl with Rails, see
-[factory_girl_rails](https://github.com/thoughtbot/factory_girl_rails).
+[factory_girl_rails](https://github.com/thoughtbot/factory_girl_rails) or [factory_factory_girl](https://github.com/st0012/factory_factory_girl).
 
 Documentation
 -------------


### PR DESCRIPTION
Hello, I use factory_girl so often that I created a gem called [factory_factory_girl](https://github.com/st0012/factory_factory_girl) two months ago. It inherited factory_girl_rails's generator and can help generating factory file more convenient. And I wonder if I can add it's link to readme to let more people know about it, thanks.